### PR TITLE
Add MCP server for log/trace querying

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	EnableProm   bool
 	FromJSONFile string
 	PromTarget   []string
+	MCPPort      int
 }
 
 func (c *Config) RenderYml() (string, error) {

--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -36,6 +36,7 @@ processors:
 exporters:
   tui:
     from_json_file: {{ if .FromJSONFile }}true{{else}}false{{end}}
+    mcp_port: {{ .MCPPort }}
 service:
   pipelines:
     traces:

--- a/config_test.go
+++ b/config_test.go
@@ -19,6 +19,7 @@ func TestConfigRenderYml(t *testing.T) {
 			"localhost:9000",
 			"other-host:9000",
 		},
+		MCPPort: 8600,
 	}
 	want := `yaml:
 receivers:
@@ -51,6 +52,7 @@ processors:
 exporters:
   tui:
     from_json_file: true
+    mcp_port: 8600
 service:
   pipelines:
     traces:
@@ -89,6 +91,7 @@ func TestConfigRenderYmlMinimum(t *testing.T) {
 		OTLPGRPCPort: 4317,
 		EnableZipkin: false,
 		EnableProm:   false,
+		MCPPort:      8600,
 	}
 	want := `yaml:
 receivers:
@@ -106,6 +109,7 @@ processors:
 exporters:
   tui:
     from_json_file: false
+    mcp_port: 8600
 service:
   pipelines:
     traces:

--- a/main.go
+++ b/main.go
@@ -42,12 +42,12 @@ func runInteractive(params otelcol.CollectorSettings) error {
 
 func newCommand(params otelcol.CollectorSettings) *cobra.Command {
 	var (
-		httpPortFlag, grpcPortFlag int
-		hostFlag                   string
-		zipkinEnabledFlag          bool
-		promEnabledFlag            bool
-		promTargetFlag             []string
-		fromJSONFileFlag           string
+		httpPortFlag, grpcPortFlag, mcpPortFlag int
+		hostFlag                                string
+		zipkinEnabledFlag                       bool
+		promEnabledFlag                         bool
+		promTargetFlag                          []string
+		fromJSONFileFlag                        string
 	)
 
 	rootCmd := &cobra.Command{
@@ -69,6 +69,7 @@ func newCommand(params otelcol.CollectorSettings) *cobra.Command {
 				EnableProm:   promEnabledFlag,
 				FromJSONFile: fromJSONFileFlag,
 				PromTarget:   promTargetFlag,
+				MCPPort:      mcpPortFlag,
 			}
 
 			if err := cfg.Validate(); err != nil {
@@ -104,5 +105,6 @@ func newCommand(params otelcol.CollectorSettings) *cobra.Command {
 	rootCmd.Flags().BoolVar(&promEnabledFlag, "enable-prom", false, "Enable the prometheus receiver")
 	rootCmd.Flags().StringVar(&fromJSONFileFlag, "from-json-file", "", "The JSON file path exported by JSON exporter")
 	rootCmd.Flags().StringArrayVar(&promTargetFlag, "prom-target", []string{}, `The target endpoints for the prometheus receiver (--prom-target "localhost:9000" --prom-target "other-host:9000")`)
+	rootCmd.Flags().IntVar(&mcpPortFlag, "mcp-port", 8600, "The port number for the MCP server")
 	return rootCmd
 }

--- a/tuiexporter/config.go
+++ b/tuiexporter/config.go
@@ -5,6 +5,7 @@ import "go.opentelemetry.io/collector/component"
 // Config defines configuration for TUI exporter.
 type Config struct {
 	FromJSONFile bool `mapstructure:"from_json_file"`
+	MCPPort      int  `mapstructure:"mcp_port"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/tuiexporter/exporter.go
+++ b/tuiexporter/exporter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/mcp"
 	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/telemetry"
 	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/tui"
 	"go.opentelemetry.io/collector/component"
@@ -14,7 +15,8 @@ import (
 )
 
 type tuiExporter struct {
-	app *tui.TUIApp
+	app    *tui.TUIApp
+	server *mcp.Server
 }
 
 func newTuiExporter(config *Config) *tuiExporter {
@@ -24,8 +26,11 @@ func newTuiExporter(config *Config) *tuiExporter {
 		//        if it runs at the same time as the UI drawing. As a workaround, wait for a second.
 		initialInterval = 1 * time.Second
 	}
+	store := telemetry.NewStore()
+	srv := mcp.New(fmt.Sprintf(":%d", config.MCPPort), store)
 	return &tuiExporter{
-		app: tui.NewTUIApp(telemetry.NewStore(), initialInterval),
+		app:    tui.NewTUIApp(store, initialInterval),
+		server: srv,
 	}
 }
 
@@ -48,7 +53,10 @@ func (e *tuiExporter) pushLogs(_ context.Context, logs plog.Logs) error {
 }
 
 // Start runs the TUI exporter
-func (e *tuiExporter) Start(_ context.Context, _ component.Host) error {
+func (e *tuiExporter) Start(ctx context.Context, _ component.Host) error {
+	if err := e.server.Start(); err != nil {
+		return err
+	}
 	go func() {
 		err := e.app.Run()
 		if err != nil {
@@ -59,6 +67,7 @@ func (e *tuiExporter) Start(_ context.Context, _ component.Host) error {
 }
 
 // Shutdown stops the TUI exporter
-func (e *tuiExporter) Shutdown(_ context.Context) error {
+func (e *tuiExporter) Shutdown(ctx context.Context) error {
+	_ = e.server.Shutdown(ctx)
 	return e.app.Stop()
 }

--- a/tuiexporter/exporter_test.go
+++ b/tuiexporter/exporter_test.go
@@ -19,12 +19,12 @@ func TestNewTuiExporter(t *testing.T) {
 	}{
 		{
 			name:                "with json file",
-			config:              &Config{FromJSONFile: true},
+			config:              &Config{FromJSONFile: true, MCPPort: 0},
 			wantInitialInterval: time.Second,
 		},
 		{
 			name:                "without json file",
-			config:              &Config{FromJSONFile: false},
+			config:              &Config{FromJSONFile: false, MCPPort: 0},
 			wantInitialInterval: 0,
 		},
 	}
@@ -35,6 +35,7 @@ func TestNewTuiExporter(t *testing.T) {
 			assert.NotNil(t, exporter)
 			assert.NotNil(t, exporter.app)
 			assert.NotNil(t, exporter.app.Store())
+			assert.NotNil(t, exporter.server)
 		})
 	}
 }
@@ -64,7 +65,7 @@ func TestPushLogs(t *testing.T) {
 }
 
 func TestStartAndShutdown(t *testing.T) {
-	exporter := newTuiExporter(&Config{})
+	exporter := newTuiExporter(&Config{MCPPort: 0})
 
 	err := exporter.Start(context.Background(), nil)
 	assert.NoError(t, err)

--- a/tuiexporter/factory.go
+++ b/tuiexporter/factory.go
@@ -25,7 +25,7 @@ func NewFactory() exporter.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{}
+	return &Config{MCPPort: 8600}
 }
 
 func createTraces(ctx context.Context, set exporter.Settings, cfg component.Config) (exporter.Traces, error) {

--- a/tuiexporter/internal/mcp/server.go
+++ b/tuiexporter/internal/mcp/server.go
@@ -1,0 +1,120 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/telemetry"
+)
+
+type Server struct {
+	store    *telemetry.Store
+	srv      *http.Server
+	listener net.Listener
+}
+
+func New(addr string, store *telemetry.Store) *Server {
+	return &Server{
+		store: store,
+		srv:   &http.Server{Addr: addr},
+	}
+}
+
+func (s *Server) Start() error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/traces/", s.handleTraces)
+	mux.HandleFunc("/logs/", s.handleLogs)
+	s.srv.Handler = mux
+
+	ln, err := net.Listen("tcp", s.srv.Addr)
+	if err != nil {
+		return err
+	}
+	s.listener = ln
+
+	go func() {
+		if err := s.srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			fmt.Printf("mcp server error: %v\n", err)
+		}
+	}()
+	return nil
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.srv.Shutdown(ctx)
+}
+
+func (s *Server) Address() string {
+	if s.listener != nil {
+		return s.listener.Addr().String()
+	}
+	return s.srv.Addr
+}
+
+type Span struct {
+	TraceID  string `json:"trace_id"`
+	SpanID   string `json:"span_id"`
+	ParentID string `json:"parent_id"`
+	Name     string `json:"name"`
+	Service  string `json:"service"`
+}
+
+func (s *Server) handleTraces(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/traces/")
+	spans, ok := s.store.GetTraceCache().GetSpansByTraceID(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	res := []Span{}
+	for _, sd := range spans {
+		res = append(res, Span{
+			TraceID:  id,
+			SpanID:   sd.Span.SpanID().String(),
+			ParentID: sd.Span.ParentSpanID().String(),
+			Name:     sd.Span.Name(),
+			Service:  telemetry.GetServiceNameFromResource(sd.ResourceSpan.Resource()),
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(res)
+}
+
+type Log struct {
+	TraceID   string `json:"trace_id"`
+	SpanID    string `json:"span_id"`
+	Body      string `json:"body"`
+	Service   string `json:"service"`
+	Severity  string `json:"severity"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/logs/")
+	logs, ok := s.store.GetLogCache().GetLogsByTraceID(id)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	res := []Log{}
+	for _, ld := range logs {
+		res = append(res, Log{
+			TraceID:   id,
+			SpanID:    ld.Log.SpanID().String(),
+			Body:      ld.Log.Body().AsString(),
+			Service:   telemetry.GetServiceNameFromResource(ld.ResourceLog.Resource()),
+			Severity:  ld.Log.SeverityText(),
+			Timestamp: ld.Log.Timestamp().AsTime().UnixNano(),
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(res)
+}

--- a/tuiexporter/internal/mcp/server_test.go
+++ b/tuiexporter/internal/mcp/server_test.go
@@ -1,0 +1,25 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/telemetry"
+)
+
+func TestServerStartShutdown(t *testing.T) {
+	store := telemetry.NewStore()
+	srv := New(":0", store)
+	err := srv.Start()
+	assert.NoError(t, err)
+
+	resp, err := http.Get("http://" + srv.Address() + "/healthz")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	err = srv.Shutdown(context.Background())
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- add a minimal MCP HTTP server so other tools can fetch traces and logs
- expose new `--mcp-port` flag
- wire MCP server into TUI exporter
- update config template and tests

## Testing
- `make lint` *(fails: `Interrupt`)*
- `make test` *(fails: `Interrupt`)*
- `make test-exporter` *(fails: `Interrupt`)*

------
https://chatgpt.com/codex/tasks/task_e_6839dfd2c794832b8f7eda33b2151907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an MCP HTTP server that exposes traces and logs via JSON endpoints, including a health check.
  - TUI exporter now starts the MCP server alongside the UI and shuts it down gracefully.
- Configuration
  - Introduced an MCP port setting, configurable via a new CLI flag and the application config.
  - Default MCP port set to 8600.
- Tests
  - Added tests for MCP server lifecycle (start, health check, shutdown) and updated exporter tests to cover the new configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->